### PR TITLE
Make hex type derive common traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ fn clean_0x(s: &str) -> &str {
 macro_rules! impl_hash {
     ($from: ident, $size: expr $(, $m:meta)*) => {
         #[repr(C)]
-        #[derive(Debug, Copy, Clone)]
+        #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
         $(#[$m])*
         /// Unformatted binary data of fixed length.
         pub struct $from (pub [u8; $size]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ fn clean_0x(s: &str) -> &str {
 macro_rules! impl_hash {
     ($from: ident, $size: expr $(, $m:meta)*) => {
         #[repr(C)]
+        #[derive(Debug, Copy, Clone)]
         $(#[$m])*
         /// Unformatted binary data of fixed length.
         pub struct $from (pub [u8; $size]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ fn clean_0x(s: &str) -> &str {
 macro_rules! impl_hash {
     ($from: ident, $size: expr $(, $m:meta)*) => {
         #[repr(C)]
-        #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+        #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
         $(#[$m])*
         /// Unformatted binary data of fixed length.
         pub struct $from (pub [u8; $size]);


### PR DESCRIPTION
I hit an issue that I cannot display the value with `H256` field:

```rust
#[derive(Debug, Copy, Clone)]
pub struct SubAddress {
    address: H256,
    offset: usize,
}
```

It seems resonable to me to add all derives that make sense and could be automatically delegated to the nested array.