### PR TITLE
Use uint instead of bigint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,13 @@ authors = ["Alexey Frolov <alexey@parity.io>"]
 license = "MIT"
 
 [dependencies]
-bigint = "4"
-rustc-hex = "1.0"
+uint = { version = "0.3", path = "../parity-common/uint" }
+# uint = "0.3" # NOT PUBLISHED YET
+rustc-hex = { version = "2.0", default-features = false}
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 
 [features]
 default = ["std"]
-std = ["bigint/std"]
+std = ["uint/std"]
 serialize = ["serde", "serde_derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,7 @@ authors = ["Alexey Frolov <alexey@parity.io>"]
 license = "MIT"
 
 [dependencies]
-uint = { version = "0.3", path = "../parity-common/uint" }
-# uint = "0.3" # NOT PUBLISHED YET
+uint = "0.3"
 rustc-hex = { version = "2.0", default-features = false}
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-hash"
-version = "1.2.1"
+version = "1.2.2"
 description = "A collection of fixed-size byte array representations"
 authors = ["Alexey Frolov <alexey@parity.io>"]
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(feature="std"), no_std)]
 
-extern crate bigint;
+extern crate uint;
 
 #[cfg(feature="std")]
 extern crate core;
@@ -21,7 +21,7 @@ use core::{ops, cmp};
 use core::cmp::{min, Ordering};
 use core::ops::{Deref, DerefMut, BitXor, BitAnd, BitOr, IndexMut, Index};
 use core::hash::{Hash, Hasher};
-use bigint::U256;
+use uint::U256;
 
 #[cfg(feature="std")]
 use rustc_hex::{FromHex, FromHexError};
@@ -172,7 +172,7 @@ macro_rules! impl_hash {
             type Err = FromHexError;
 
             fn from_str(s: &str) -> Result<$from, FromHexError> {
-                let a = s.from_hex()?;
+                let a : Vec<u8> = s.from_hex()?;
                 if a.len() != $size {
                     return Err(FromHexError::InvalidHexLength);
                 }


### PR DESCRIPTION
~~NOTE: do not merge before https://github.com/paritytech/parity-common/pull/25 is merged and `uint` v0.3 is published~~

This is blocking https://github.com/paritytech/pwasm-ethereum/pull/13