### PR TITLE
Update uint dependency from 0.3 to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Alexey Frolov <alexey@parity.io>"]
 license = "MIT"
 
 [dependencies]
-uint = "0.3"
+uint = "0.4"
 rustc-hex = { version = "2.0", default-features = false}
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }


### PR DESCRIPTION
This just updates the `uint` dependency from version `0.3` to `0.4`.
Nothing had to be adjusted for that. However, with this we can clean up our dependency tree in some `pwasm-*` projects.