### PR TITLE
Add license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "parity-hash"
 version = "1.2.2"
 description = "A collection of fixed-size byte array representations"
+repository = "https://github.com/fckt/parity-hash"
 authors = ["Alexey Frolov <alexey@parity.io>"]
 license = "MIT"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Alexey Frolov <alexey@parity.io>"]
 license = "MIT"
 
 [dependencies]
-uint = "0.3"
+uint = "0.4"
 rustc-hex = { version = "2.0", default-features = false}
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,15 @@
+APACHE License
+
+Copyright 2017 Alexey (github: fckt)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 by Alexey (github: fckt)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 A shareable collection of commonly used fixed-sized byte arrays.
+
+## License
+
+Licensed under either of
+
+ * Apache license, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Dual licence: [![badge][license-mit-badge]](LICENSE-MIT) [![badge][license-apache-badge]](LICENSE-APACHE)
+
+[license-mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
+[license-apache-badge]: https://img.shields.io/badge/license-APACHE-orange.svg


### PR DESCRIPTION
This adds a license (actually two) to `parity-hash`.

I chose `MIT` and `APACHE2.0` combination license since it is simply the same as used by the `uint` dependency of `parity-hash`. So makes sense to license it under the same.

Hope you are in favor of that since licensing can be pretty important even for small crates such as these.