### PR TITLE
Add crates io repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "parity-hash"
 version = "1.2.2"
 description = "A collection of fixed-size byte array representations"
+repository = "https://github.com/fckt/parity-hash"
 authors = ["Alexey Frolov <alexey@parity.io>"]
 license = "MIT"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Alexey Frolov <alexey@parity.io>"]
 license = "MIT"
 
 [dependencies]
-uint = "0.3"
+uint = "0.4"
 rustc-hex = { version = "2.0", default-features = false}
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }


### PR DESCRIPTION
Adds a repo link for crates.io.

It is just a convenience feature. Not important but still very useful.